### PR TITLE
Makefile: allow overriding paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ RELEASE_SCRIPTS         = scripts/bash scripts/make
 INSTALL                 = install
 
 # Installation locations
-BIN_PATH                = $(PREFIX)/bin
-LIB_PATH                = $(PREFIX)/lib
-DOC_PATH                = $(PREFIX)/share/doc
+BIN_PATH                ?= $(PREFIX)/bin
+LIB_PATH                ?= $(PREFIX)/lib
+DOC_PATH                ?= $(PREFIX)/share/doc
 LADSPA_PATH             = $(LIB_PATH)/ladspa
 LV2_PATH                = $(LIB_PATH)/lv2
 VST_PATH                = $(LIB_PATH)/vst


### PR DESCRIPTION
The paths for binaries, libraries and documentation are derived from the
PREFIX variable, but then are hard-coded to bin, lib and share/doc.

Some Linux distributions redefine them for packaging, so make the Makefile
aware of it.

Signed-off-by: Johannes Thumshirn <jthumshirn@suse.de>