### PR TITLE
Sort scan_directory file list

### DIFF
--- a/src/utils/resource_gen.cpp
+++ b/src/utils/resource_gen.cpp
@@ -421,8 +421,9 @@ namespace lsp
             return -STATUS_NO_MEM;
 
         // Try to scan directory
-        DIR *dirhdl     = opendir(realpath);
-        if (dirhdl == NULL)
+        struct dirent **namelist;
+        int scandirn = scandir(realpath, &namelist, NULL, alphasort);
+        if (scandirn == -1)
         {
             fprintf(stderr, "Could not open directory %s\n", realpath);
             free(realpath);
@@ -432,12 +433,10 @@ namespace lsp
         int result      = STATUS_OK;
         struct stat st;
 
-        while (true)
+        for(int i = scandirn; i>0;)
         {
             // Read next entry
-            struct dirent *ent  = readdir(dirhdl);
-            if (ent == NULL)
-                break;
+            struct dirent *ent  = namelist[--i];
 
             // Skip dot and dot-dot
             if (!strcmp(ent->d_name, "."))
@@ -509,7 +508,10 @@ namespace lsp
         }
 
         // Close directory
-        closedir(dirhdl);
+        while (scandirn--) {
+                free(namelist[scandirn]);
+        }
+        free(namelist);
         free(realpath);
 
         return result;


### PR DESCRIPTION
Sort scan_directory file list
so that xml_resource.cpp builds in a reproducible way
in spite of indeterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.

Note: scandir(3) only works on POSIX-compliant systems like Linux, BSD and MacOSX
not MSWindows

This PR was done while working on reproducible builds for openSUSE.