### PR TITLE
Replace "VERSION" with "LSP_VERSION" to avoid clashes with environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,13 +75,13 @@ export PHP_PLUGINS      = $(OBJDIR)/plugins.php
 FILE                    = $(@:$(OBJDIR)/%.o=%.cpp)
 FILES                   =
 
-LADSPA_ID              := $(ARTIFACT_ID)-ladspa-$(VERSION)
-LV2_ID                 := $(ARTIFACT_ID)-lv2-$(VERSION)
-VST_ID                 := $(ARTIFACT_ID)-lxvst-$(VERSION)
-JACK_ID                := $(ARTIFACT_ID)-jack-$(VERSION)
-PROFILE_ID             := $(ARTIFACT_ID)-profile-$(VERSION)
-SRC_ID                 := $(ARTIFACT_ID)-src-$(VERSION)
-DOC_ID                 := $(ARTIFACT_ID)-doc-$(VERSION)
+LADSPA_ID              := $(ARTIFACT_ID)-ladspa-$(LSP_VERSION)
+LV2_ID                 := $(ARTIFACT_ID)-lv2-$(LSP_VERSION)
+VST_ID                 := $(ARTIFACT_ID)-lxvst-$(LSP_VERSION)
+JACK_ID                := $(ARTIFACT_ID)-jack-$(LSP_VERSION)
+PROFILE_ID             := $(ARTIFACT_ID)-profile-$(LSP_VERSION)
+SRC_ID                 := $(ARTIFACT_ID)-src-$(LSP_VERSION)
+DOC_ID                 := $(ARTIFACT_ID)-doc-$(LSP_VERSION)
 
 .DEFAULT_GOAL          := all
 .PHONY: all experimental trace debug tracefile debugfile profile gdb test testdebug testprofile compile test_compile

--- a/scripts/make/tools.mk
+++ b/scripts/make/tools.mk
@@ -6,7 +6,7 @@ TOOL_PHP                = php
 
 # Setup preferred flags
 FLAG_RELRO              = -Wl,-z,relro,-z,now
-FLAG_VERSION            = -DLSP_MAIN_VERSION=\"$(VERSION)\" -DLSP_INSTALL_PREFIX=\"$(PREFIX)\"
+FLAG_VERSION            = -DLSP_MAIN_VERSION=\"$(LSP_VERSION)\" -DLSP_INSTALL_PREFIX=\"$(PREFIX)\"
 FLAG_CTUNE              = -std=c++98 \
                           -fno-exceptions -fno-rtti \
                           -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables \

--- a/scripts/make/version.mk
+++ b/scripts/make/version.mk
@@ -3,8 +3,8 @@ ARTIFACT_ID             = $(PRODUCT)-plugins
 R3D_ARTIFACT_ID         = $(ARTIFACT_ID)-r3d
 
 # Package version
-ifndef VERSION
-  VERSION                 = 1.1.21
+ifndef LSP_VERSION
+  LSP_VERSION                 = 1.1.21
 endif
 
-export VERSION
+export LSP_VERSION


### PR DESCRIPTION
To avoid losing time troubleshooting strange build errors.
I propose to use a more specific variable name, in case "VERSION" is already an environment variable on the build host ...