### PR TITLE
core/ipc/Mutex: use sched_yield instead of pthread_yield

### DIFF
--- a/include/core/ipc/Mutex.h
+++ b/include/core/ipc/Mutex.h
@@ -18,6 +18,7 @@
     #include <sys/syscall.h>
     #include <unistd.h>
     #include <pthread.h>
+    #include <sched.h>
     #include <errno.h>
 #else
     #include <pthread.h>

--- a/src/core/ipc/Mutex.cpp
+++ b/src/core/ipc/Mutex.cpp
@@ -108,7 +108,7 @@ namespace lsp
                 // Issue wait
                 res = syscall(SYS_futex, &nLock, FUTEX_WAIT, 0, NULL, 0, 0);
                 if ((res == ENOSYS) || (res == EAGAIN))
-                    pthread_yield();
+                    sched_yield();
             }
         }
 


### PR DESCRIPTION
This allows lsp-plugins to be built with musl libc, as pthread_yield()
is a glibc-only alias to sched_yield().

Furthermore, glibc itself recommends the use of sched_yield() over
pthread_yield(), as written in pthread_yield(3).