### PR TITLE
Fix compilation with musl libc

### DIFF
--- a/include/data/cvector.h
+++ b/include/data/cvector.h
@@ -25,6 +25,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 
 #define CVECTOR_GROW        16
 

--- a/include/test/main/executor.h
+++ b/include/test/main/executor.h
@@ -633,7 +633,7 @@ namespace lsp
     }
 #endif /* PLATFORM_WINDOWS */
 
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) && defined(__GLIBC__)
     void TestExecutor::start_memcheck(test::Test *v)
     {
         if (!pCfg->mtrace)

--- a/include/test/main/types.h
+++ b/include/test/main/types.h
@@ -42,7 +42,7 @@
     #include <fcntl.h>
 #endif /* PLATFORM_UNIX_COMPATIBLE */
 
-#ifdef PLATFORM_LINUX
+#if defined(PLATFORM_LINUX) && defined(__GLIBC__)
     #include <mcheck.h>
 #endif /* PLATFORM_LINUX */
 

--- a/include/testing/mtest/3d/common/X11Renderer.h
+++ b/include/testing/mtest/3d/common/X11Renderer.h
@@ -30,7 +30,7 @@
 #include <X11/X.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 #include <rendering/backend.h>
 #include <core/ipc/Library.h>

--- a/src/testing/mtest/3d/boolean3d.cpp
+++ b/src/testing/mtest/3d/boolean3d.cpp
@@ -41,7 +41,7 @@
 #include <GL/gl.h>
 #include <GL/glx.h>
 #include <GL/glu.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 //#define TEST_DEBUG
 

--- a/src/testing/mtest/3d/bsp_context.cpp
+++ b/src/testing/mtest/3d/bsp_context.cpp
@@ -39,7 +39,7 @@
 #include <X11/keysymdef.h>
 #include <GL/gl.h>
 #include <GL/glx.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 //#define TEST_DEBUG
 

--- a/src/testing/mtest/3d/reflections3d.cpp
+++ b/src/testing/mtest/3d/reflections3d.cpp
@@ -39,7 +39,7 @@
 #include <X11/keysymdef.h>
 #include <GL/gl.h>
 #include <GL/glx.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 //#define TEST_DEBUG
 

--- a/src/ui/ws/x11/X11Display.cpp
+++ b/src/ui/ws/x11/X11Display.cpp
@@ -23,7 +23,7 @@
 
 #ifdef USE_X11_DISPLAY
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <errno.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
`musl` libc doesn't support `mcheck` stuff, so we should skip it if `__GLIBC__` isn't defined.
This PR also fixes some warnings.
