### PR TITLE
Use https instead of http when possible

### DIFF
--- a/COMPLETED.txt
+++ b/COMPLETED.txt
@@ -115,7 +115,7 @@ unfa:
   Amadeus Folego:
     You can check calf-analyzer as well (https://www.youtube.com/watch?v=TWfqcf-EyUE).
 
-    Something like baudline (http://baudline.com) with LV2 would be amazing.
+    Something like baudline (https://baudline.com) with LV2 would be amazing.
 
 ==== Link order of libraries ====
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -258,7 +258,7 @@ Tobbe:
     A channel-strip style drum plugin would be really great for Linux. Maybe someone will get inspired one day and make it.
     Wish I could! Not my area of expertise.
     
-    http://www.kvraudio.com/product/bdm-broken-drum-machine-by-nusofting
+    https://www.kvraudio.com/product/bdm-broken-drum-machine-by-nusofting
     BDM is a plugin instrument designed for the musicians who love chaos and usually find the unpredictable behaviour of an
     uncontrollable sound machine stimulating and inspiring.
     BDM basically offers 4 drum pads like an old, small, beat box with: Bass Drum, Snare, Hi-Hat and Stick, each of those has
@@ -359,10 +359,10 @@ Tobbe:
 
   pms967:
     would be really nice to have: a good "Blumelein Shuffler".
-    See: http://www.aes.org/e-lib/browse.cfm?elib=6686
-    See also here: http://www.audiosignal.co.uk/Resources/Stereo_shuffling_A4.pdf
+    See: https://www.aes.org/e-lib/browse.cfm?elib=6686
+    See also here: https://www.audiosignal.co.uk/Resources/Stereo_shuffling_A4.pdf
     (there you'll also find a very interesting PFB-based analog implementation, which may be inspiring)
-    ...and here: http://kokkinizita.linuxaudio.org/linuxaudio/zita-bls1-doc/quickguide.html
+    ...and here: https://kokkinizita.linuxaudio.org/linuxaudio/zita-bls1-doc/quickguide.html
     (but this otherwise very nice implementation -unfortunately available only as a stand-alone jack app, no plugin-
     is somewhat specific and optimized for a special use-case).
     Well, I know that a similar results can be obtained e.g. applying different shelving eq. to the mid/side

--- a/res/demo/art_delay/art-delay-mono.cfg
+++ b/res/demo/art_delay/art-delay-mono.cfg
@@ -9,7 +9,7 @@
 #   LADSPA identifier:   5002170
 # 
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 # 
 #-------------------------------------------------------------------------------
 

--- a/res/demo/art_delay/art-delay-stereo.cfg
+++ b/res/demo/art_delay/art-delay-stereo.cfg
@@ -9,7 +9,7 @@
 #   LADSPA identifier:   5002171
 # 
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 # 
 #-------------------------------------------------------------------------------
 

--- a/res/demo/comp_delay/comp_delay_mono.cfg
+++ b/res/demo/comp_delay/comp_delay_mono.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002065
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/comp_delay/comp_delay_stereo.cfg
+++ b/res/demo/comp_delay/comp_delay_stereo.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002066
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/comp_delay/comp_delay_x2_stereo.cfg
+++ b/res/demo/comp_delay/comp_delay_x2_stereo.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002067
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/crossover/lr.cfg
+++ b/res/demo/crossover/lr.cfg
@@ -9,7 +9,7 @@
 #   LADSPA identifier:   5002168
 # 
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 # 
 #-------------------------------------------------------------------------------
 

--- a/res/demo/crossover/mono.cfg
+++ b/res/demo/crossover/mono.cfg
@@ -9,7 +9,7 @@
 #   LADSPA identifier:   5002166
 # 
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 # 
 #-------------------------------------------------------------------------------
 

--- a/res/demo/crossover/ms.cfg
+++ b/res/demo/crossover/ms.cfg
@@ -9,7 +9,7 @@
 #   LADSPA identifier:   5002169
 # 
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 # 
 #-------------------------------------------------------------------------------
 

--- a/res/demo/crossover/stereo.cfg
+++ b/res/demo/crossover/stereo.cfg
@@ -9,7 +9,7 @@
 #   LADSPA identifier:   5002167
 # 
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 # 
 #-------------------------------------------------------------------------------
 

--- a/res/demo/mb-compressor/lr.cfg
+++ b/res/demo/mb-compressor/lr.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002136
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/mb-compressor/mono.cfg
+++ b/res/demo/mb-compressor/mono.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002134
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/mb-compressor/ms.cfg
+++ b/res/demo/mb-compressor/ms.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002137
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/mb-compressor/sc_lr.cfg
+++ b/res/demo/mb-compressor/sc_lr.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002140
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/mb-compressor/sc_mono.cfg
+++ b/res/demo/mb-compressor/sc_mono.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002138
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/mb-compressor/sc_ms.cfg
+++ b/res/demo/mb-compressor/sc_ms.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002141
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/mb-compressor/sc_stereo.cfg
+++ b/res/demo/mb-compressor/sc_stereo.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002139
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/mb-compressor/stereo.cfg
+++ b/res/demo/mb-compressor/stereo.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002135
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/mb-expander/mb-expander-lr.cfg
+++ b/res/demo/mb-expander/mb-expander-lr.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002148
 # 
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 # 
 #-------------------------------------------------------------------------------
 

--- a/res/demo/mb-expander/mb-expander-mono.cfg
+++ b/res/demo/mb-expander/mb-expander-mono.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002146
 # 
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 # 
 #-------------------------------------------------------------------------------
 

--- a/res/demo/mb-expander/mb-expander-ms.cfg
+++ b/res/demo/mb-expander/mb-expander-ms.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002149
 # 
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 # 
 #-------------------------------------------------------------------------------
 

--- a/res/demo/mb-expander/mb-expander-stereo.cfg
+++ b/res/demo/mb-expander/mb-expander-stereo.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002147
 # 
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 # 
 #-------------------------------------------------------------------------------
 

--- a/res/demo/para_eq/para_equalizer_x16_mono.cfg
+++ b/res/demo/para_eq/para_equalizer_x16_mono.cfg
@@ -8,7 +8,7 @@
 #   LADSPA identifier:   5002074
 # 
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 # 
 #-------------------------------------------------------------------------------
 

--- a/res/demo/room_builder/room_builder_mono.cfg
+++ b/res/demo/room_builder/room_builder_mono.cfg
@@ -7,7 +7,7 @@
 #   VST identifier:      ????
 # 
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 # 
 #-------------------------------------------------------------------------------
 

--- a/res/demo/room_builder/room_builder_stereo.cfg
+++ b/res/demo/room_builder/room_builder_stereo.cfg
@@ -7,7 +7,7 @@
 #   VST identifier:      ????
 # 
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 # 
 #-------------------------------------------------------------------------------
 

--- a/res/demo/sampler/multi/x12.cfg
+++ b/res/demo/sampler/multi/x12.cfg
@@ -7,7 +7,7 @@
 #   VST identifier:      clrs
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/sampler/multi/x12_do.cfg
+++ b/res/demo/sampler/multi/x12_do.cfg
@@ -7,7 +7,7 @@
 #   VST identifier:      7zkj
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/sampler/multi/x24.cfg
+++ b/res/demo/sampler/multi/x24.cfg
@@ -7,7 +7,7 @@
 #   VST identifier:      visl
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/sampler/multi/x24_do.cfg
+++ b/res/demo/sampler/multi/x24_do.cfg
@@ -7,7 +7,7 @@
 #   VST identifier:      vimj
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/sampler/multi/x48.cfg
+++ b/res/demo/sampler/multi/x48.cfg
@@ -7,7 +7,7 @@
 #   VST identifier:      hnj4
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/sampler/multi/x48_do.cfg
+++ b/res/demo/sampler/multi/x48_do.cfg
@@ -7,7 +7,7 @@
 #   VST identifier:      blyi
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/sampler/single/mono.cfg
+++ b/res/demo/sampler/single/mono.cfg
@@ -7,7 +7,7 @@
 #   VST identifier:      ca4r
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/res/demo/sampler/single/stereo.cfg
+++ b/res/demo/sampler/single/stereo.cfg
@@ -7,7 +7,7 @@
 #   VST identifier:      kjw3
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/scripts/Octave/SyncChirpProcessor_CoeffcientsMatrixTest/powersin_ampl.m
+++ b/scripts/Octave/SyncChirpProcessor_CoeffcientsMatrixTest/powersin_ampl.m
@@ -1,5 +1,5 @@
 function C = powersin_ampl(N, A)
-    % Code from http://ant-novak.com/Nonlinear_System_Identification_Waveguide.php
+    % Code from https://ant-novak.com/pages/sss/
 
     % C = powersin_ampl(N,A);
     % .... N = number of harmonics

--- a/src/doc/config/config.php
+++ b/src/doc/config/config.php
@@ -1,4 +1,4 @@
 <?php
 	$SITEROOT = '';
-	$SITE_URL = 'http://lsp-plug.in/';
+	$SITE_URL = 'https://lsp-plug.in/';
 ?>

--- a/src/doc/manuals/controls.php
+++ b/src/doc/manuals/controls.php
@@ -213,10 +213,10 @@ control parameters of some device or set of similar devices.</p>
 <h2>Inline display</h2>
 
 <p>Inline displays are not widgets or elements of plugin's UI at all. Instead of this, they're part of
-the host UI since the <a href="http://ardour.org/">Ardour DAW</a> implemented Inline Display extension for
+the host UI since the <a href="https://ardour.org/">Ardour DAW</a> implemented Inline Display extension for
 LV2 format.</p>
 <p>So they're available in the Ardour's mixer strip even if UI is not shown. Inline displays also are
-available in <a href="http://harrisonconsoles.com/">Mixbus DAW</a> as the relative to Ardour product.</p>
+available in <a href="https://harrisonconsoles.com/">Mixbus DAW</a> as the relative to Ardour product.</p>
 <p>Because inline display is an LV2-specific exension, it is available only for LV2 version of LSP plugins.
 But standalone JACK versions of plugins that support inline displays in LV2, draw them on window's icon.</p>
 
@@ -330,7 +330,7 @@ configuration file contents:</p>
 #   LADSPA identifier:   5002065
 #
 # (C) Linux Studio Plugins Project 
-#   http://lsp-plug.in/ 
+#   https://lsp-plug.in/ 
 #
 #-------------------------------------------------------------------------------
 

--- a/src/doc/manuals/licensing.php
+++ b/src/doc/manuals/licensing.php
@@ -8,7 +8,7 @@ compensate time spent for development.</p>
 
 <p>Binary distributions of the software are completely free but the source code for each plugin
 will be published under the free license only after the donation goal is reached. Detailed
-information is available at official site: <a href="http://lsp-plug.in/">http://lsp-plug.in/</a></p>
+information is available at official site: <a href="https://lsp-plug.in/">https://lsp-plug.in/</a></p>
 
 <p>Below the text of license used by <b>LSP Plugins</b> is present.</p>
 

--- a/src/doc/manuals/overview.php
+++ b/src/doc/manuals/overview.php
@@ -2,9 +2,9 @@
 <p><b>LSP (Linux Studio Plugins)</b> is a collection of open-source plugins compatible with following formats:</p>
 <ul>
 	<li><b>LADSPA</b> - set of plugins for <a href="https://en.wikipedia.org/wiki/LADSPA">Linux Audio Developer's Simple Plugin API</a></li>
-	<li><b>LV2</b> - set of plugins and UIs for <a href="http://lv2plug.in/">Linux Audio Developer's Simple Plugin API (LADSPA) version 2</a></li>
-	<li><b>LinuxVST</b> - set of plugins and UIs for <a href="http://www.steinberg.net/">Steinberg's VST 2.4</a> format ported on GNU/Linux Platform</li>
-	<li><b>JACK</b> - Standalone versions for <a href="http://jackaudio.org/">JACK Audio connection Kit</a> with UI</li>
+	<li><b>LV2</b> - set of plugins and UIs for <a href="https://lv2plug.in/">Linux Audio Developer's Simple Plugin API (LADSPA) version 2</a></li>
+	<li><b>LinuxVST</b> - set of plugins and UIs for <a href="https://www.steinberg.net/">Steinberg's VST 2.4</a> format ported on GNU/Linux Platform</li>
+	<li><b>JACK</b> - Standalone versions for <a href="https://jackaudio.org/">JACK Audio connection Kit</a> with UI</li>
 </ul>
 
 <p>The basic idea is to fill the lack of good and useful plugins under the GNU/Linux platform.</p>
@@ -13,4 +13,4 @@
 
 <p>Currently project is developed and maintained by LSP Project Team with the main founder and developer at the head &ndash; Vladimir Sadovnikov.</p>
 
-<p>The official site ot the project is located here: <a href="http://lsp-plug.in/">http://lsp-plug.in/</a></p>
+<p>The official site ot the project is located here: <a href="https://lsp-plug.in/">https://lsp-plug.in/</a></p>


### PR DESCRIPTION
I tested all the links.  (Some links I did not change are broken.)
I separated by type of file.
In doubt, I did not touch links when they might be used as "keys" link in RDF or XML or Turtle ...