### PR TITLE
Broken link and updates

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -438,9 +438,9 @@ Tobbe:
   is a shame.
 
 ==== Spring reverb ====
-  Looking at scientific publications like this one, an accurate physical model of a spring reverb
-  in real time seems out of reach for a longtime. 
-  http://www.ness-music.eu/wp-content/uploads/2013/06/dafx13.pdf
+  Looking at scientific publications, an accurate physical model of a spring reverb in real time seems out of reach for a longtime. 
+  This one in 2013 present high "Computational cost": https://www.researchgate.net/publication/262731418_NUMERICAL_SIMULATION_OF_SPRING_REVERBERATION 
+  More recently, 2020 the accuracy could be improved, but no mention of better performance: https://www.researchgate.net/publication/354658314_MODAL_SPRING_REVERB_BASED_ON_DISCRETISATION_OF_THE_THIN_HELICAL_SPRING_MODEL
   
   Do we have any resonator plugins? I used to use the on in ableton live years ago to create some
   quite nice spring reverb sounding fx when combined with the autofilter before the input. I can't


### PR DESCRIPTION
The old link was broken. The paper can be found on ResearchGate.
It is also in the references [15] in the newer paper (2020). 
I hesitated to send a mail instead. I am not sure changing the text is relevant.