### PR TITLE
Add riscv support, fix macro comment typos

### DIFF
--- a/include/3rdparty/steinberg/vst2.h
+++ b/include/3rdparty/steinberg/vst2.h
@@ -58,6 +58,11 @@
             #define __cdecl
         #elif defined(__mips__) || defined(__mips) || defined(__MIPS__)
             #define __cdecl
+        #elif defined(__riscv) && __riscv_xlen == 64
+            #define VST_64BIT_PLATFORM      1
+            #define __cdecl
+        #elif defined(__riscv) && __riscv_xlen == 32
+            #define __cdecl
         #endif /* __cdecl */
     #endif /* __cdecl */
 #endif /* __GNUC__ */
@@ -79,7 +84,7 @@
     #endif
 
     #ifndef VST_64BIT_PLATFORM
-        #define VST_64BIT_PLATFORM  (__x86_64__) || (__aarch64__) || (__ppc64__) || (__s390x__) || (__zarch__)
+        #define VST_64BIT_PLATFORM  (__x86_64__) || (__aarch64__) || (__ppc64__) || (__s390x__) || (__zarch__) || defined(__riscv) && __riscv_xlen == 64
     #endif /* VST_64BIT_PLATFORM */
 #else
     #ifndef VST_64BIT_PLATFORM

--- a/include/common/types.h
+++ b/include/common/types.h
@@ -56,6 +56,10 @@
     #define ARCH_MIPS
 #elif defined(__sparc__) || defined(__sparc)
     #define ARCH_SPARC
+#elif defined(__riscv) && __riscv_xlen == 64
+    #define ARCH_RISCV64
+#elif defined(__riscv) && __riscv_xlen == 32
+    #define ARCH_RISCV32
 #endif
 
 //-----------------------------------------------------------------------------
@@ -150,7 +154,7 @@
         #define ARCH_ARM8
         #define IF_ARCH_ARM8(...)        __VA_ARGS__
     #endif
-#endif /* defined(ARCH_ARM) */
+#endif /* defined(ARCH_AARCH64) */
 
 #if defined(ARCH_PPC)
     #define IF_ARCH_PPC(...)            __VA_ARGS__
@@ -164,28 +168,42 @@
     #define ARCH_PPC64_ASM(...)         __asm__ __volatile__ ( __VA_ARGS__ )
 
     #define ARCH_STRING                 "ppc64"
-#endif /* defined(ARCH_PPC) */
+#endif /* defined(ARCH_PPC64) */
 
 #if defined(ARCH_S390)
     #define IF_ARCH_S390(...)           __VA_ARGS__
     #define ARCH_S390_ASM(...)          __asm__ __volatile__ ( __VA_ARGS__ )
 
     #define ARCH_STRING                 "S390"
-#endif /* defined(ARCH_PPC) */
+#endif /* defined(ARCH_S390) */
 
 #if defined(ARCH_MIPS)
     #define IF_ARCH_MIPS(...)           __VA_ARGS__
     #define ARCH_MIPS_ASM(...)          __asm__ __volatile__ ( __VA_ARGS__ )
 
     #define ARCH_STRING                 "MIPS"
-#endif /* defined(ARCH_PPC) */
+#endif /* defined(ARCH_MIPS) */
 
 #if defined(ARCH_SPARC)
     #define IF_ARCH_SPARC(...)          __VA_ARGS__
     #define ARCH_SPARC_ASM(...)         __asm__ __volatile__ ( __VA_ARGS__ )
 
     #define ARCH_STRING                 "SPARC"
-#endif /* defined(ARCH_PPC) */
+#endif /* defined(ARCH_SPARC) */
+
+#if defined(ARCH_RISCV64)
+    #define IF_ARCH_RISCV64(...)          __VA_ARGS__
+    #define ARCH_RISCV64_ASM(...)         __asm__ __volatile__ ( __VA_ARGS__ )
+
+    #define ARCH_STRING                 "RISCV64"
+#endif /* defined(ARCH_RISCV64) */
+
+#if defined(ARCH_RISCV32)
+    #define IF_ARCH_RISCV32(...)          __VA_ARGS__
+    #define ARCH_RISCV32_ASM(...)         __asm__ __volatile__ ( __VA_ARGS__ )
+
+    #define ARCH_STRING                 "RISCV32"
+#endif /* defined(ARCH_RISCV32) */
 
 #if defined(ARCH_LE)
     #define __IF_LEBE(le, be)   le
@@ -336,6 +354,14 @@
 #ifndef ARCH_SPARC_ASM
     #define ARCH_SPARC_ASM(...)
 #endif /* ARCH_SPARC_ASM */
+
+#ifndef ARCH_RISCV64_ASM
+    #define ARCH_RISCV64_ASM(...)
+#endif /* ARCH_RISCV64_ASM */
+
+#ifndef ARCH_RISCV32_ASM
+    #define ARCH_RISCV32_ASM(...)
+#endif /* ARCH_RISCV32_ASM */
 
 #define __ASM_ARG_TMP(var)                      __IF_32P("=&g"(var)) __IF_32NP("=&r"(var)) __IF_64("=&r"(var))
 #define __ASM_ARG_RW(var)                       __IF_32P("+g"(var))  __IF_32NP("+r"(var))  __IF_64("+r"(var))
@@ -501,7 +527,15 @@
 
 #ifndef IF_ARCH_SPARC
     #define IF_ARCH_SPARC(...)
-#endif /* IF_ARCH_MIPS */
+#endif /* IF_ARCH_SPARC */
+
+#ifndef IF_ARCH_RISCV64
+    #define IF_ARCH_RISCV64(...)
+#endif /* IF_ARCH_RISCV64 */
+
+#ifndef IF_ARCH_RISCV32
+    #define IF_ARCH_RISCV32(...)
+#endif /* IF_ARCH_RISCV32 */
 
 //-----------------------------------------------------------------------------
 // Default platform


### PR DESCRIPTION
This enables build on riscv. And fix some macro comment typos.