### PR TITLE
Fix BUILD_PROFILE=armv8a build error

### DIFF
--- a/src/dsp/Makefile
+++ b/src/dsp/Makefile
@@ -44,6 +44,9 @@ endif
 ifeq ($(BUILD_PROFILE), armv7ve)
 LINK_OBJECTS           += $(ARM_IMPL) $(NEON_D32_IMPL)
 endif
+ifeq ($(BUILD_PROFILE), armv8a)
+LINK_OBJECTS           += $(ARM_IMPL) $(NEON_D32_IMPL)
+endif
 ifeq ($(BUILD_PROFILE), arm32)
 LINK_OBJECTS           += $(ARM_IMPL) $(NEON_D32_IMPL)
 endif


### PR DESCRIPTION
Without this, attempting to build 32-bit lsp-plugins on an arm64 system
fails with

undefined reference to `arm::dsp_init()')

. Simple enough to fix, as even even leaving aside the "this IS 32-bit
Arm" argument, the compiler flags for this build profile show that it
should be functionally the same as armv7a.

Signed-off-by: Marek Szuba <marek.szuba@cern.ch>