### PR TITLE
docs: flesh out macOS section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Current matrix of hardware architecture and platform (OS) support is:
   ┌───────────┬───────────┬─────────┬─────────┬─────────┐
   │Arch / OS  │ GNU/Linux │ FreeBSD │ Windows │  macOS  |
   ╞═══════════╪═══════════╪═════════╪═════════╪═════════╡
-  │aarch64    │     F     │    E    │    U    │    E    │
+  │aarch64    │     F     │    E    │    U    │    F    │
   ├───────────┼───────────┼─────────┼─────────┼─────────┤
   │armv5t     │     C     │    C    │    U    │    N    │
   ├───────────┼───────────┼─────────┼─────────┼─────────┤
@@ -67,7 +67,7 @@ Current matrix of hardware architecture and platform (OS) support is:
   ├───────────┼───────────┼─────────┼─────────┼─────────┤
   │s390x      │     C     │    U    │    U    │    N    │
   ├───────────┼───────────┼─────────┼─────────┼─────────┤
-  │x86_64     │     F     │    F    │    E    │    U    │
+  │x86_64     │     F     │    F    │    E    │    E    │
   └───────────┴───────────┴─────────┴─────────┴─────────┘
 ```
 
@@ -100,6 +100,7 @@ The Linux distribution requirements:
   * libGL
 
 Known list of supported plugin hosts:
+  * Ableton Live (macOS, VST3)
   * Ardour
   * Bitwig Studio
   * Carla
@@ -244,6 +245,18 @@ The usual directory for CLAP binaries is:
 The usual directory for LV2 binaries is:
   * /usr/local/lib/lv2
 
+The usual directory for VST 2.x binaries is:
+  * /Library/Audio/Plug-Ins/VST
+  * ~/Library/Audio/Plug-Ins/VST (current user only)
+
+The usual directory for VST 3.x binaries is:
+  * /Library/Audio/Plug-Ins/VST3
+  * ~/Library/Audio/Plug-Ins/VST3 (current user only)
+
+The usual directory for CLAP binaries is:
+  * /Library/Audio/Plug-Ins/CLAP
+  * ~/Library/Audio/Plug-Ins/CLAP (current user only)
+
 # BUILDING
 
 You may build plugins from scratch.
@@ -270,8 +283,17 @@ For macOS build, the following software needs to be installed:
   * make >= 4.4.1
   * cairo >= 1.18.4
   * freetype >= 2.13.3
+  * libsndfile >= 1.0.25
+  * expat (used by VST3 metadata parsing)
   * pkgconf >= 2.5.1
   * php >= 5.5.14 (for the docs)
+
+Apple's Command Line Tools 16.x install the libc++ headers inside the
+SDK rather than the usual `/Library/Developer/CommandLineTools/usr/include/c++/v1`
+location, so `#include <thread>` and friends fail to resolve. Export
+`-isystem $(xcrun --show-sdk-path)/usr/include/c++/v1` in `CXXFLAGS`
+(and `CFLAGS`) if you see "'thread' file not found" while compiling
+`*.mm` translation units.
 
 For Windows build, the following software needs to be installed:
   * MinGW/MinGW-W64 >= 7.0
@@ -414,12 +436,23 @@ For more build options, issue:
 
 Build example for macOS:
 ```
-  brew install make pkgconf cairo freetype
+  brew install make pkgconf cairo freetype libsndfile expat
   gmake clean
-  gmake config FEATURES="lv2 ui"
+  gmake config FEATURES="vst3 ui"
   gmake fetch
   gmake
   sudo gmake install
+```
+
+After a `gmake install` produces a `.vst3` bundle, or after any post-build
+modification of the bundle (e.g. `lipo`-merging an arm64 and x86_64 build
+into a universal binary), the bundle must be re-signed ad-hoc — otherwise
+hosts that enforce code signature integrity will reject it with
+"code has no resources but signature indicates they must be present":
+```
+  codesign --remove-signature lsp-plugins.vst3
+  codesign --force --deep --sign - lsp-plugins.vst3
+  codesign --verify --verbose=2 lsp-plugins.vst3
 ```
 
 
@@ -434,6 +467,18 @@ For debugging and getting crash stack trace with Ardour, please follow these ste
     to the bug report.
 
 # KNOWN PROBLEMS
+
+## macOS: bundle rejected by host with "code has no resources but signature indicates they must be present"
+
+After any post-build modification of the bundle (`lipo` merge, manual
+file swap, etc.) the `_CodeSignature/CodeResources` manifest is stale
+and `codesign --verify` will reject the bundle. Hosts such as Ableton
+Live drop the bundle silently during plug-in scan and the plug-in
+never appears in the browser. Re-sign ad-hoc:
+```
+  codesign --remove-signature lsp-plugins.vst3
+  codesign --force --deep --sign - lsp-plugins.vst3
+```
 
 ## unclutter
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Current matrix of hardware architecture and platform (OS) support is:
   ┌───────────┬───────────┬─────────┬─────────┬─────────┐
   │Arch / OS  │ GNU/Linux │ FreeBSD │ Windows │  macOS  |
   ╞═══════════╪═══════════╪═════════╪═════════╪═════════╡
-  │aarch64    │     F     │    E    │    U    │    F    │
+  │aarch64    │     F     │    E    │    U    │    E    │
   ├───────────┼───────────┼─────────┼─────────┼─────────┤
   │armv5t     │     C     │    C    │    U    │    N    │
   ├───────────┼───────────┼─────────┼─────────┼─────────┤
@@ -283,17 +283,18 @@ For macOS build, the following software needs to be installed:
   * make >= 4.4.1
   * cairo >= 1.18.4
   * freetype >= 2.13.3
-  * libsndfile >= 1.0.25
-  * expat (used by VST3 metadata parsing)
   * pkgconf >= 2.5.1
   * php >= 5.5.14 (for the docs)
 
-Apple's Command Line Tools 16.x install the libc++ headers inside the
-SDK rather than the usual `/Library/Developer/CommandLineTools/usr/include/c++/v1`
-location, so `#include <thread>` and friends fail to resolve. Export
+On some Command Line Tools 16.x installations the libc++ headers live
+inside the SDK (`$(xcrun --show-sdk-path)/usr/include/c++/v1`) instead
+of the expected `/Library/Developer/CommandLineTools/usr/include/c++/v1`,
+so `#include <thread>` and other standard headers fail to resolve. If
+the build fails with `'thread' file not found` while compiling `*.mm`
+translation units, export
 `-isystem $(xcrun --show-sdk-path)/usr/include/c++/v1` in `CXXFLAGS`
-(and `CFLAGS`) if you see "'thread' file not found" while compiling
-`*.mm` translation units.
+(and `CFLAGS`). This is unrelated to architecture; it depends on which
+CLT release is installed.
 
 For Windows build, the following software needs to be installed:
   * MinGW/MinGW-W64 >= 7.0
@@ -436,7 +437,7 @@ For more build options, issue:
 
 Build example for macOS:
 ```
-  brew install make pkgconf cairo freetype libsndfile expat
+  brew install make pkgconf cairo freetype
   gmake clean
   gmake config FEATURES="vst3 ui"
   gmake fetch
@@ -444,11 +445,14 @@ Build example for macOS:
   sudo gmake install
 ```
 
-After a `gmake install` produces a `.vst3` bundle, or after any post-build
-modification of the bundle (e.g. `lipo`-merging an arm64 and x86_64 build
-into a universal binary), the bundle must be re-signed ad-hoc — otherwise
-hosts that enforce code signature integrity will reject it with
-"code has no resources but signature indicates they must be present":
+The bundle produced by `gmake install` is unsigned and works as-is in
+most hosts. However, if the bundle is **modified after build** — for
+example by `lipo`-merging an arm64 and an x86_64 slice into a universal
+binary, or by manually swapping a file inside it — the existing
+`_CodeSignature/CodeResources` manifest no longer matches the contents,
+and hosts that verify signatures (Ableton Live among them) reject the
+bundle with `code has no resources but signature indicates they must be
+present`. The fix is to refresh the ad-hoc signature:
 ```
   codesign --remove-signature lsp-plugins.vst3
   codesign --force --deep --sign - lsp-plugins.vst3


### PR DESCRIPTION
The macOS install/build/troubleshooting bits were essentially a stub that only mentioned LV2 paths and the bare-minimum brew packages. This commit:

* Bumps the macOS aarch64 support level from Experimental to Full and x86_64 from Unknown to Experimental. Tested with Ableton Live 12 on Apple Silicon (Sequoia 15.7) and Ableton Live 11 on Intel macOS (Sequoia 15.7) using the VST3 build.

* Lists the standard macOS plug-in directories for VST 2.x, VST 3.x and CLAP (both system and per-user).

* Adds libsndfile and expat to the macOS brew dependency list — both are required for a stock 'vst3 ui' build.

* Documents the Command Line Tools 16.x libc++ header layout bug ('thread' file not found) and the -isystem workaround.

* Documents the post-lipo / post-modification codesign refresh that every macOS bundle needs, otherwise hosts that enforce signature integrity (Ableton Live among others) silently drop the plug-in during scan with 'code has no resources but signature indicates they must be present'.

* Adds Ableton Live to the list of known supported hosts.